### PR TITLE
change db cleaning strategy for js test to deletion

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,5 +1,6 @@
 RSpec.configure do |config|
   config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end
 
@@ -8,7 +9,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, js: true) do
-    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :deletion
   end
 
   config.before(:each) do


### PR DESCRIPTION
Tests for JS features no longer fail since the database cleaning strategy was changed to deletion for JS feature tests.
